### PR TITLE
Fix url of 'theme' and 'tags' in exampleSite/config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -51,7 +51,7 @@ copyright = "&copy; Copyright notice"
 
 [[menu.main]]
     identifier = "theme"
-    name = "theme"
+    name = "/theme"
     weight = 3
 
 [[menu.main]]
@@ -68,5 +68,5 @@ copyright = "&copy; Copyright notice"
 
 [[menu.main]]
     name = "Tags"
-    url = "tags"
+    url = "/tags"
     weight = 4


### PR DESCRIPTION
If you do not put `'/'` at the beginning, url will become `'/about/tags'` when transitioning from `'/about'` to `'/tags'`

@mismith0227 
とても良いテーマを作っていただきありがとうございます。
exampleSite/config.tomlをコピーして使っていたのですが、メニューのリンク遷移に問題があったので修正してみました。