### PR TITLE
Hide content from index page using front matter param

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 {{ partial "header.html" . }}
-{{ range $index, $page := (.Paginate (where .Data.Pages "Type" "posts")).Pages }}
+{{ range $index, $page := (.Paginate (where (where .Data.Pages "Type" "posts") ".Params.hidden" "!=" "true" )).Pages }}
 {{ if ne $index 0 }}
 {{ end }}
 {{ .Render "li" }}


### PR DESCRIPTION
I often want to share posts with colleagues to ask for feedback before I officially publish.

This PR hides posts from the index page if they have `hidden: true` in their front matter. This means you can only read the post if you happen to know the URL, much like GitHub's secret gist feature.