### PR TITLE
Process BaseURL using `sanitizeurl`

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,5 +1,5 @@
 {{ partial "header.html" . }}
-{{ $baseurl := .Site.BaseURL}}
+{{ $baseurl := .Site.BaseURL | sanitizeurl }}
 <section>
   <h2>{{ .Title }}</h2>
   <ul>


### PR DESCRIPTION
Using `sanitizeurl` to ensure no extra slash in result url.  
Otherwise, it will produce something like `http://example.com//foo/bar`, which can cause error on some HTTP server.