### PR TITLE
Adding support for custom css styles

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -3,6 +3,7 @@ languageCode = "en-us"
 Title = "Your site title"
 # Copyright notice. This is displayer in the footer.
 copyright = "&copy; Copyright notice"
+custom_css = "/static/css/custom.css"
 
 [params]
   paginate = 10

--- a/exampleSite/static/css/custom.css
+++ b/exampleSite/static/css/custom.css
@@ -1,0 +1,1 @@
+/* Add your custom styles adjustments here */

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -40,6 +40,10 @@
   {{ .Hugo.Generator -}}
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600" rel="stylesheet">
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css" />
+  <!-- Custom css files as define in config.toml -->
+  {{ range .Site.Params.custom_css -}}
+    <link rel="stylesheet" href="{{ . | absURL }}">
+  {{- end }}
   {{- with .Site.Params.favicon }}
   <link rel='icon' type='image/x-icon' href="{{ . | absURL }}" />
   {{- end -}}


### PR DESCRIPTION
This PPR add functionality to define `custom_css` files in config and add them to `static/css`.
This will allow easy adjustments and customization of the styles.