### PR TITLE
.Prev and .Next deprecated, update pagination to .NextPage and .PrevPage

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -38,14 +38,14 @@
     <nav class="p-pagination c-pagination">
       <div class="c-pagination__ctrl">
         <div class="c-pagination__newer">
-          {{ if .Prev }}
-          <a href="{{ .Prev.Permalink }}">Newer</a>
+          {{ if .NextPage }}
+          <a href="{{ .NextPage.Permalink }}">Newer</a>
           {{ else }}
           {{ end }}
         </div>
         <div class="c-pagination__older">
-          {{ if .Next }}
-          <a href="{{ .Next.Permalink }}">Older</a>
+          {{ if .PrevPage }}
+          <a href="{{ .PrevPage.Permalink }}">Older</a>
           {{ else }}
           {{ end }}
         </div>


### PR DESCRIPTION
As of Hugo 0.50, .Prev/.Next are .NextPage/.PrevPage respectively. Reference https://github.com/gohugoio/hugo/pull/5252