### PR TITLE
fix(head): update Hugo functions which will be deprecated

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -36,8 +36,8 @@
   {{ else }}
   <meta property="og:type" content="website" />
   {{ end }}
-  <!-- Hugo Version number -->
-  {{ .Hugo.Generator -}}
+  <!-- Hugo Version Number -->
+  {{ hugo.Generator -}}
   
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css" />
   <!-- Custom css files as define in config.toml -->
@@ -47,8 +47,10 @@
   {{- with .Site.Params.favicon }}
   <link rel='icon' type='image/x-icon' href="{{ . | absURL }}" />
   {{- end -}}
-  {{ if eq .URL "/" }}
-  <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+  {{ if eq .RelPermalink "/" }}
+  {{ with .OutputFormats.Get "RSS" -}}
+  <link href="{{ .Permalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+  {{ end -}}
   {{ end }}
   <script type="text/javascript" src="{{ .Site.BaseURL }}js/bundle.js"></script>
   {{ partial "head_custom.html" . }}


### PR DESCRIPTION
With Hugo version 0.55.1, this template gives the following warnings:

```
WARN 2019/04/14 20:47:15 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
WARN 2019/04/14 20:47:15 Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url.
WARN 2019/04/14 20:47:15 Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like:
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}.
Total in 109 ms
```

This PR updates the `head.html` template to use the updated Hugo syntax.