### PR TITLE
build: update for Hugo v0.57+

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 {{ partial "header.html" . }}
 <h2 class="c-title p-tag-title">{{ .Title }}</h2>
-{{ range $index, $page := (.Paginate (where .Data.Pages "Type" "posts")).Pages }}
+{{ range $index, $page := (.Paginate (where .Site.RegularPages "Type" "posts")).Pages }}
 {{ if ne $index 0 }}
 {{ end }}
 {{ .Render "li" }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
 {{ partial "header.html" . }}
-{{ range $index, $page := (.Paginate (where (where .Data.Pages "Type" "posts") ".Params.hidden" "!=" "true" )).Pages }}
+{{ range $index, $page := (.Paginate (where (where .Site.RegularPages "Type" "posts") ".Params.hidden" "!=" "true" )).Pages }}
 {{ if ne $index 0 }}
 {{ end }}
 {{ .Render "li" }}


### PR DESCRIPTION
In Hugo v0.57.0, a breaking change was introduced to the `.Pages`
variable [1]. This adopts the new .Site.RegularPages syntax.

https://github.com/gohugoio/hugo/issues/6153