### PR TITLE
(Next|Prev)Page -> (Next|Prev)InSection

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -38,14 +38,14 @@
     <nav class="p-pagination c-pagination">
       <div class="c-pagination__ctrl">
         <div class="c-pagination__newer">
-          {{ if .NextPage }}
-          <a href="{{ .NextPage.Permalink }}">Newer</a>
+          {{ if .NextInSection }}
+          <a href="{{ .NextInSection.Permalink }}">Newer</a>
           {{ else }}
           {{ end }}
         </div>
         <div class="c-pagination__older">
-          {{ if .PrevPage }}
-          <a href="{{ .PrevPage.Permalink }}">Older</a>
+          {{ if .PrevInSection }}
+          <a href="{{ .PrevInSection.Permalink }}">Older</a>
           {{ else }}
           {{ end }}
         </div>


### PR DESCRIPTION
When there are multiple sections, NextPage and PrevPage will interleave
pages in them.  To match existing pagination and perhaps user intuition,
instead use NextInSection and PrevInSection which will restrict to e.g.
posts.