### PR TITLE
Fix a bug on listing posts in tag, categories

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,9 +1,18 @@
 {{ partial "header.html" . }}
 <h2 class="c-title p-tag-title">{{ .Title }}</h2>
+{{ if isset .Site.Taxonomies "tags" }}
+{{ $mytag := .Title }}
+{{ range $index, $page := (.Paginate (where .Data.Pages "Type" "posts")).Pages }}
+{{ if ne $index 0 }}
+{{ end }}
+{{ .Render "li" }}
+{{ end }}
+{{ else }}
 {{ range $index, $page := (.Paginate (where .Site.RegularPages "Type" "posts")).Pages }}
 {{ if ne $index 0 }}
 {{ end }}
 {{ .Render "li" }}
+{{ end }}
 {{ end }}
 {{ partial "pagination.html" .Paginator }}
 {{ partial "siteinfo.html" . }}


### PR DESCRIPTION
Description:
Fix a problem on listing posts with specific tag, and category.

In a default layout, list.xml, there is no routines to draw items depends on tags or categories. 
I do pull request to fix the problem with using .Data.Pages variable.
