### PR TITLE
Use standard Hugo template for Google Analytics

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,6 +5,9 @@ Title = "Your site title"
 copyright = "&copy; Copyright notice"
 custom_css = "/static/css/custom.css"
 
+# Google Analytics API key.
+googleAnalytics = "Your Google Analytics tracking id"
+
 [params]
   paginate = 10
   # Social accounts. Link to these accounts are displayed in the header and
@@ -28,8 +31,6 @@ custom_css = "/static/css/custom.css"
   medium = "Your Medium username"
   # Disqus shortname
   disqus = ""
-  # Google Analytics API key.
-  ga_api_key = "Your Google Analytics tracking id"
   author = "Your Name"
   authorwebsite = "example.com"
   avatar = "/path/to/avatar"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -25,19 +25,6 @@
     </p>
   </footer>
 
-  {{ if not .Site.IsServer }}
-    {{ with ($.Param "ga_api_key") }}
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', '{{ . }}', 'auto');
-      ga('send', 'pageview');
-    </script>
-    {{ end }}
-  {{ end }} 
-
   {{- partial "footer_custom.html" . }}
 </body>
 </html>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,6 +38,10 @@
   {{ end }}
   <!-- Hugo Version Number -->
   {{ hugo.Generator -}}
+
+  {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production") }}
+  {{ template "_internal/google_analytics_async.html" . }}
+  {{ end }}
   
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css" />
   <!-- Custom css files as define in config.toml -->


### PR DESCRIPTION
It has been raised already in #129 that there's a default setting for Google Analytics that makes it portable across different themes.

https://gohugo.io/templates/internal/#google-analytics