### PR TITLE
Better env check for google analytics script

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -39,10 +39,10 @@
   <!-- Hugo Version Number -->
   {{ hugo.Generator -}}
 
-  {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production") }}
+  {{ if not .Site.IsServer }}
   {{ template "_internal/google_analytics_async.html" . }}
   {{ end }}
-  
+
   <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css" />
   <!-- Custom css files as define in config.toml -->
   {{ range ($.Param "custom_css") -}}


### PR DESCRIPTION
Using `HUGO_ENV` or `Site.Params.env` to enable google analytics script is bad because it is not intuitive to the user. This PR replaces the env check with .`Site.IsServer`, which is usually true for development.

Reference: https://gohugo.io/variables/site/#site-variables-list