### PR TITLE
Add header_custom for injecting custom header content

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,4 +16,5 @@
     </p>
     {{ end }}
   </header>
+  {{- partial "header_custom.html" . }}
   <main id="main" class="l-main">

--- a/layouts/partials/header_custom.html
+++ b/layouts/partials/header_custom.html
@@ -1,0 +1,4 @@
+<!--
+If you want to include any custom html just before <main>, put it in /layouts/partials/header_custom.html
+Do not put anything in this file - it's only here so that hugo won't throw an error if /layouts/partials/header_custom.html doesn't exist.
+-->


### PR DESCRIPTION
DESCRIPTION: Adds a header_custom.html that parallels footer_custom.html and head_custom.html,
allowing custom styling (e.g. injecting the menu or other navigational content) between
the site header and page content.