### PR TITLE
Refactor 'posted on' code to a timestamp partial

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -3,10 +3,6 @@
     <h2 class="c-title c-article__title"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
     <p class="c-article__meta">
       {{ partial "timestamp.html" . }}
-      Posted on
-      <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
-        {{ .Date.Format "Jan 2, 2006" }}
-      </time>
     </p>
   </header>
   <div class="c-article__summary">

--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -2,6 +2,7 @@
   <header>
     <h2 class="c-title c-article__title"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
     <p class="c-article__meta">
+      {{ partial "timestamp.html" . }}
       Posted on
       <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
         {{ .Date.Format "Jan 2, 2006" }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,10 +5,7 @@
     <h1>{{ .Title }}</h1>
     <div>
       <div class="c-time">
-        Posted on
-        <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
-          {{ .Date.Format "Jan 2, 2006" }}
-        </time>
+        {{ partial "timestamp.html" . }}
       </div>
       {{ range .Params.tags }}
       <a href="{{ $baseurl }}/tags/{{ . | urlize }}" class="c-tag">{{ . }}</a>

--- a/layouts/partials/timestamp.html
+++ b/layouts/partials/timestamp.html
@@ -1,0 +1,4 @@
+Posted on
+<time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
+  {{ .Date.Format "Jan 2, 2006" }}
+</time>


### PR DESCRIPTION
This is particularly useful for users (i.e. me) who would like to change the default date formatting and perhaps remove the 'posted on' text.