### PR TITLE
feat: add 'hideDate' parameter to hide the date

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ $ cp themes/hugo_theme_pickles/exampleSite/config.toml .
 
 Now, you can start editing this file and add your own information!
 
+## Customisation
+
+To hide the date in any page or post, set the `hideDate` parameter in the front matter:
+
+```
+---
+hideDate: true
+---
+```
+
 ## Contributing
 
 Pull requests, bug fixes and new features are welcome!

--- a/exampleSite/content/posts/hiding-the-date.md
+++ b/exampleSite/content/posts/hiding-the-date.md
@@ -1,0 +1,27 @@
+---
+author: "Dave Kerr"
+date: 2020-06-11
+linktitle: Hiding the Date
+title: Hiding the Date
+weight: 10
+hideDate: true
+---
+
+
+## Introduction
+
+Hiding the date in a page or post is easy! Just set `hideDate` to `true` in your front matter.
+
+As an example, the front matter for this page is:
+
+```
+---
+date: 2020-06-11
+linktitle: Hiding the Date
+title: Hiding the Date
+weight: 10
+hideDate: true
+---
+```
+
+Piece of cake!

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,9 +4,11 @@
   <header>
     <h1>{{ .Title }}</h1>
     <div>
-      <div class="c-time">
-        {{ partial "timestamp.html" . }}
-      </div>
+      {{ if not .Params.hideDate }}
+        <div class="c-time">
+          {{ partial "timestamp.html" . }}
+        </div>
+      {{ end }}
       {{ range .Params.tags }}
       <a href="{{ $baseurl }}/tags/{{ . | urlize }}" class="c-tag">{{ . }}</a>
       {{ end }}


### PR DESCRIPTION
This closes issue #71.

By the way @mismith0227 - when I follow the instructions to run the site, I cannot serve the `exampleSite` folder, it complains about the zoom shortcode not being present - do you know why this is? I was hoping to be able to test this on the example site first!