### PR TITLE
fix: serving the example site locally with `yarn run hugo` now works

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,22 +85,26 @@ Please create feature branches from [develop](https://github.com/mismith0227/hug
 
 1.  Install Node modules
 
-        $ yarn
+```sh
+yarn
+```
 
 1.  Run gulp. You don't need to install gulp globally.
 
-        // Development
-        $ yarn run dev
-        $ // On another tab
-        $ hugo server
+```
+// Development
+$ yarn run dev
+$ // On another tab
+$ yarn run hugo
 
-        // Production (compress)
-        $ yarn run prod
-        $ // On another tab
-        $ hugo server
+// Production (compress)
+$ yarn run prod
+$ // On another tab
+$ yarn run hugo
 
-        // Build
-        $ yarn run build
+// Build
+$ yarn run build
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "hugo": "hugo server",
+    "hugo": "hugo server -s exampleSite --baseUrl http://localhost --themesDir=../../ --theme=hugo_theme_pickles",
     "dev": "gulp",
     "prod": "gulp --env production",
     "build": "gulp build --env production",


### PR DESCRIPTION
Currently if you clone the code and follow the instructions, running `hugo serve` will result in the following error:

```
Error: Unable to locate config file or config directory. Perhaps you need to create a new site.
       Run `hugo help new` for details.
```

This PR updates the `yarn run hugo` command to correctly serve the `exampleSite` folder with the local version of the theme. Live reload etc is also supported. This PR also updates the documents.

Fixes #147 