### PR TITLE
feat: add last modified time to posts

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -7,10 +7,16 @@ copyright = "&copy; Copyright notice"
 # Google Analytics API key.
 googleAnalytics = "Your Google Analytics tracking id"
 
+# enable get info from git commits, such as file modification time.
+# so we don't have to manually update it.
+enableGitInfo = true
+
 [params]
   paginate = 10
   # Hide the date on posts
   # hideDate = true
+  # Hide last modified date on posts
+  # hideModifiedDate = true
   # Hide the word count on posts and in the posts list
   # hideWordCount = true
   # Hide the reading time on posts and in the posts list

--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -3,6 +3,9 @@
     <h2 class="c-title c-article__title"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
     <p class="c-article__meta">
       {{ partial "timestamp.html" . }}
+      {{ if not (.Param "hideModifiedDate") }}
+         | {{ partial "modified_date.html" . }}
+      {{ end }}
       {{ if not (.Param "hideWordCount") }}
          | {{ partial "word_count.html" . }}
       {{ end }}

--- a/layouts/partials/modified_date.html
+++ b/layouts/partials/modified_date.html
@@ -1,0 +1,4 @@
+Updated on
+<time datetime="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
+  {{ .Lastmod.Format "Jan 2, 2006" }}
+</time>


### PR DESCRIPTION
add a new param: hideModifiedDate. If set to false, the last modified time of post is displayed.A site global configuration is also added, enableGitInfo. If set to true, the last modified time will get from git commits. More can see this: https://gohugo.io/getting-started/configuration/#enablegitinfo

preview 

<img width="548" alt="image" src="https://user-images.githubusercontent.com/35746578/145832176-65aa4b80-db67-4cce-b791-cfc8a59cc4c6.png">

