### PR TITLE
Move paginate out of params

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -11,8 +11,9 @@ googleAnalytics = "Your Google Analytics tracking id"
 # so we don't have to manually update it.
 enableGitInfo = true
 
+paginate = 10
+
 [params]
-  paginate = 10
   # Hide the date on posts
   # hideDate = true
   # Hide last modified date on posts


### PR DESCRIPTION
Paginate was not working for me on Hugo v0.82 until I moved it out of `[params]`