### PR TITLE
Adds i18n support

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,84 @@
+[updated-on]
+other = "Updated on"
+
+[skip-to-content]
+other = "Skip to content"
+
+[newer]
+other = "Newer"
+
+[older]
+other = "Older"
+
+[page-count]
+other = "Page {{ .PageNumber }} of {{.TotalPages}}"
+
+[social-medium]
+other = "medium"
+
+[social-twitter]
+other = "twitter"
+
+[reading-time-minutes]
+zero = "{{ . }}mins"
+one = "{{ . }}min"
+other = "{{ . }}mins"
+
+[see-also]
+other = ""
+
+[contact-me]
+other = "Contact me"
+
+[posted-on]
+other = "Posted on"
+
+[word-count]
+zero = "{{ . }} words"
+one = "{{ . }} word"
+other = "{{ . }} words"
+
+[social-facebook]
+other = "facebook"
+
+[social-instagram]
+other = "instagram"
+
+[social-github]
+other = "github"
+
+[social-gitlab]
+other = "gitlab"
+
+[social-npm]
+other = "npm"
+
+[social-codepen]
+other = "codepen"
+
+[social-dribbble]
+other = "dribbble"
+
+[social-500px]
+other = "500px"
+
+[social-flickr]
+other = "flickr"
+
+[social-pinterest]
+other = "pinterest"
+
+[social-tumblr]
+other = "tumblr"
+
+[social-vimeo]
+other = "vimeo"
+
+[social-youtube]
+other = "youtube"
+
+[social-linkedin]
+other = "linkedin"
+
+[social-strava]
+other = "strava"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -20,9 +20,9 @@ other = "medium"
 other = "twitter"
 
 [reading-time-minutes]
-zero = "{{ . }}mins"
-one = "{{ . }}min"
-other = "{{ . }}mins"
+zero = "{{ .ReadingTime }}mins"
+one = "{{ .ReadingTime }}min"
+other = "{{ .ReadingTime }}mins"
 
 [see-also]
 other = ""
@@ -34,9 +34,9 @@ other = "Contact me"
 other = "Posted on"
 
 [word-count]
-zero = "{{ . }} words"
-one = "{{ . }} word"
-other = "{{ . }} words"
+zero = "{{ .WordCount }} words"
+one = "{{ .WordCount }} word"
+other = "{{ .WordCount }} words"
 
 [social-facebook]
 other = "facebook"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -11,7 +11,7 @@ other = "Newer"
 other = "Older"
 
 [page-count]
-other = "Page {{ .PageNumber }} of {{.TotalPages}}"
+other = "Page {{ .PageNumber }} of {{ .TotalPages }}"
 
 [social-medium]
 other = "medium"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -1,0 +1,84 @@
+[updated-on]
+other = "Atualizado em"
+
+[skip-to-content]
+other = "Pular para conteúdo"
+
+[newer]
+other = "Mais recentes"
+
+[older]
+other = "Mais antigos"
+
+[page-count]
+other = "Página {{ .PageNumber }} de {{.TotalPages}}"
+
+[social-medium]
+other = "medium"
+
+[social-twitter]
+other = "twitter"
+
+[reading-time-minutes]
+zero = "{{ . }}mins"
+one = "{{ . }}min"
+other = "{{ . }}mins"
+
+[see-also]
+other = ""
+
+[contact-me]
+other = "Entre em contato"
+
+[posted-on]
+other = "Publicado em"
+
+[word-count]
+zero = "{{ . }} palavras"
+one = "{{ . }} palavra"
+other = "{{ . }} palavras"
+
+[social-facebook]
+other = "facebook"
+
+[social-instagram]
+other = "instagram"
+
+[social-github]
+other = "github"
+
+[social-gitlab]
+other = "gitlab"
+
+[social-npm]
+other = "npm"
+
+[social-codepen]
+other = "codepen"
+
+[social-dribbble]
+other = "dribbble"
+
+[social-500px]
+other = "500px"
+
+[social-flickr]
+other = "flickr"
+
+[social-pinterest]
+other = "pinterest"
+
+[social-tumblr]
+other = "tumblr"
+
+[social-vimeo]
+other = "vimeo"
+
+[social-youtube]
+other = "youtube"
+
+[social-linkedin]
+other = "linkedin"
+
+[social-strava]
+other = "strava"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -20,9 +20,9 @@ other = "medium"
 other = "twitter"
 
 [reading-time-minutes]
-zero = "{{ . }}mins"
-one = "{{ . }}min"
-other = "{{ . }}mins"
+zero = "{{ .ReadingTime }}mins"
+one = "{{ .ReadingTime }}min"
+other = "{{ .ReadingTime }}mins"
 
 [see-also]
 other = ""
@@ -34,9 +34,9 @@ other = "Entre em contato"
 other = "Publicado em"
 
 [word-count]
-zero = "{{ . }} palavras"
-one = "{{ . }} palavra"
-other = "{{ . }} palavras"
+zero = "{{ .WordCount }} palavras"
+one = "{{ .WordCount }} palavra"
+other = "{{ .WordCount }} palavras"
 
 [social-facebook]
 other = "facebook"

--- a/i18n/pt.toml
+++ b/i18n/pt.toml
@@ -11,7 +11,7 @@ other = "Mais recentes"
 other = "Mais antigos"
 
 [page-count]
-other = "Página {{ .PageNumber }} de {{.TotalPages}}"
+other = "Página {{ .PageNumber }} de {{ .TotalPages }}"
 
 [social-medium]
 other = "medium"

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
 <html lang="{{ .Site.LanguageCode }}" prefix="og: http://ogp.me/ns#">
 {{ partial "head.html" . }}
 <body>
-  <a href="#main" class="skip-link p-screen-reader-text">Skip to content</a>
+  <a href="#main" class="skip-link p-screen-reader-text">{{ i18n "skip-to-content" }}</a>
   {{ partial "svgpack-sprite.html" . }}
   <header class="l-header">
     {{ if .IsPage }}

--- a/layouts/partials/link.html
+++ b/layouts/partials/link.html
@@ -4,7 +4,7 @@
   <li class="c-links__item">
     <a href="https://medium.com/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>medium</title>
+        <title>{{ i18n "social-medium" }}</title>
         <use xlink:href="#icon-medium"></use>
       </svg>
     </a>
@@ -14,7 +14,7 @@
   <li class="c-links__item">
     <a href="https://twitter.com/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>twitter</title>
+        <title>{{ i18n "social-twitter" }}</title>
         <use xlink:href="#icon-twitter"></use>
       </svg>
     </a>
@@ -24,7 +24,7 @@
   <li class="c-links__item">
     <a href="https://facebook.com/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>facebook</title>
+        <title>{{ i18n "social-facebook" }}</title>
         <use xlink:href="#icon-facebook"></use>
       </svg>
     </a>
@@ -34,7 +34,7 @@
   <li class="c-links__item">
     <a href="https://instagram.com/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>instagram</title>
+        <title>{{ i18n "social-instagram" }}</title>
         <use xlink:href="#icon-instagram"></use>
       </svg>
     </a>
@@ -44,7 +44,7 @@
   <li class="c-links__item">
     <a href="https://github.com/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>github</title>
+        <title>{{ i18n "social-github" }}</title>
         <use xlink:href="#icon-github"></use>
       </svg>
     </a>
@@ -54,7 +54,7 @@
   <li class="c-links__item">
     <a href="https://gitlab.com/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>gitlab</title>
+        <title>{{ i18n "social-gitlab" }}</title>
         <use xlink:href="#icon-gitlab"></use>
       </svg>
     </a>
@@ -64,7 +64,7 @@
   <li class="c-links__item">
     <a href="https://www.npmjs.com/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>npm</title>
+        <title>{{ i18n "social-npm" }}</title>
         <use xlink:href="#icon-npm"></use>
       </svg>
     </a>
@@ -74,7 +74,7 @@
   <li class="c-links__item">
     <a href="https://codepen.io/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>codepen</title>
+        <title>{{ i18n "social-codepen" }}</title>
         <use xlink:href="#icon-codepen"></use>
       </svg>
     </a>
@@ -84,7 +84,7 @@
   <li class="c-links__item">
     <a href="https://dribbble.com/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>dribbble</title>
+        <title>{{ i18n "social-dribbble" }}</title>
         <use xlink:href="#icon-dribbble"></use>
       </svg>
     </a>
@@ -94,7 +94,7 @@
   <li class="c-links__item">
     <a href="https://500px.com/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>500px</title>
+        <title>{{ i18n "social-500px" }}</title>
         <use xlink:href="#icon-500px"></use>
       </svg>
     </a>
@@ -104,7 +104,7 @@
   <li class="c-links__item">
     <a href="https://www.flickr.com/photos/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>flickr</title>
+        <title>{{ i18n "social-flickr" }}</title>
         <use xlink:href="#icon-flickr"></use>
       </svg>
     </a>
@@ -114,7 +114,7 @@
   <li class="c-links__item">
     <a href="https://www.pinterest.jp/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>pinterest</title>
+        <title>{{ i18n "social-pinterest" }}</title>
         <use xlink:href="#icon-pinterest"></use>
       </svg>
     </a>
@@ -124,7 +124,7 @@
   <li class="c-links__item">
     <a href="https://www.tumblr.com/blog/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>tumblr</title>
+        <title>{{ i18n "social-tumblr" }}</title>
         <use xlink:href="#icon-tumblr"></use>
       </svg>
     </a>
@@ -134,7 +134,7 @@
   <li class="c-links__item">
     <a href="https://vimeo.com/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>vimeo</title>
+        <title>{{ i18n "social-vimeo" }}</title>
         <use xlink:href="#icon-vimeo"></use>
       </svg>
     </a>
@@ -144,7 +144,7 @@
   <li class="c-links__item">
     <a href="https://www.youtube.com/user/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>youtube</title>
+        <title>{{ i18n "social-youtube" }}</title>
         <use xlink:href="#icon-youtube"></use>
       </svg>
     </a>
@@ -154,7 +154,7 @@
   <li class="c-links__item">
     <a href="https://linkedin.com/in/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>linkedin</title>
+        <title>{{ i18n "social-linkedin" }}</title>
         <use xlink:href="#icon-linkedin"></use>
       </svg>
     </a>
@@ -164,7 +164,7 @@
   <li class="c-links__item">
     <a href="https://www.strava.com/athletes/{{ . }}" target="_blank">
       <svg viewBox="0 0 64 64" class="c-links__icon">
-        <title>strava</title>
+        <title>{{ i18n "social-strava" }}</title>
         <use xlink:href="#icon-strava"></use>
       </svg>
     </a>

--- a/layouts/partials/modified_date.html
+++ b/layouts/partials/modified_date.html
@@ -1,4 +1,4 @@
-Updated on
+{{ i18n "updated-on" }}
 <time datetime="{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
   {{ .Lastmod.Format "Jan 2, 2006" }}
 </time>

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -2,14 +2,14 @@
   <div class="c-pagination__ctrl">
     <div class="c-pagination__newer">
       {{if .HasPrev}}
-      <a href="{{ .Prev.URL }}">Newer</a>
+      <a href="{{ .Prev.URL }}">{{ i18n "newer" }}</a>
       {{end}}
     </div>
     <div class="c-pagination__older">
       {{if .HasNext}}
-      <a href="{{ .Next.URL }}">Older</a>
+      <a href="{{ .Next.URL }}">{{ i18n "older" }}</a>
       {{end}}
     </div>
   </div>
-  <span class="c-pagination__count p-pagination__count">Page {{ .PageNumber }} of {{.TotalPages}}</span>
+  <span class="c-pagination__count p-pagination__count">{{ i18n "page-count" . }}</span>
 </nav>

--- a/layouts/partials/reading_time.html
+++ b/layouts/partials/reading_time.html
@@ -1,1 +1,1 @@
-~{{ i18n "reading-time-minutes" .ReadingTime}}
+~{{ i18n "reading-time-minutes" . }}

--- a/layouts/partials/reading_time.html
+++ b/layouts/partials/reading_time.html
@@ -1,7 +1,1 @@
-{{ if gt .ReadingTime 1 }}
-{{ .Scratch.Set "readingTime" "mins" }}
-{{ else }}
-{{ .Scratch.Set "readingTime" "min" }}
-{{ end }}
-~{{.ReadingTime}} {{ .Scratch.Get "readingTime" }}
-
+~{{ i18n "reading-time-minutes" .ReadingTime}}

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,7 +1,7 @@
 {{ $related := .Site.RegularPages.Related . | first 6 }}
 {{ with $related }}
 <section class="p-related">
-  <h3>See Also</h3>
+  <h3>{{ i18n "see-also" }}</h3>
   <div class="p-related__list">
     <div class="swiper swiper-container">
       <ul class="swiper-wrapper">

--- a/layouts/partials/siteinfo.html
+++ b/layouts/partials/siteinfo.html
@@ -16,7 +16,7 @@
     {{ with ($.Param "contact") }}
     <p>
       <a href="{{ . }}">
-        Contact me
+        {{ i18n "contact-me" }}
       </a>
     </p>
     {{ end }}

--- a/layouts/partials/timestamp.html
+++ b/layouts/partials/timestamp.html
@@ -1,4 +1,4 @@
-Posted on
+{{ i18n "posted-on" }}
 <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" | safeHTML }}">
   {{ .Date.Format "Jan 2, 2006" }}
 </time>

--- a/layouts/partials/word_count.html
+++ b/layouts/partials/word_count.html
@@ -1,1 +1,1 @@
-{{ .WordCount }} words 
+{{ i18n "word-count" .WordCount }}

--- a/layouts/partials/word_count.html
+++ b/layouts/partials/word_count.html
@@ -1,1 +1,1 @@
-{{ i18n "word-count" .WordCount }}
+{{ i18n "word-count" . }}


### PR DESCRIPTION
Hey! :)

For my blog, I needed to adapt the code a bit to be able to add portuguese translations into it.

# Changelog

* Removes static strings from the template and replace it with `i18n` function calls;
* Adds `i18n` folder containing original english strings + brazilian portuguese translations

Thanks for sharing the template on GitHub!