### PR TITLE
fix invalid tag url

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,4 @@
 {{ partial "header.html" . }}
-{{ $baseurl := .Site.BaseURL | urlize }}
 <article class="p-article">
   <header>
     <h1>{{ .Title }}</h1>
@@ -20,7 +19,7 @@
         </div>
       </div>
       {{ range .Params.tags }}
-      <a href="{{ $baseurl }}/tags/{{ . | urlize }}" class="c-tag">{{ . }}</a>
+      <a href="{{ absURL "tags"}}/{{ . | urlize }}" class="c-tag">{{ . }}</a>
       {{ end }}
     </div>
     {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,11 +1,10 @@
 {{ partial "header.html" . }}
-{{ $baseurl := .Site.BaseURL | urlize }}
 <section>
   <h2>{{ .Title }}</h2>
   <ul>
     {{ $data := .Data }}
     {{ range $key, $value := .Data.Terms }}
-    <li><a href="{{ $baseurl }}/{{ $data.Plural }}/{{ $key | urlize }}">{{ $key }}</a> ({{ len $value }})</li>
+    <li><a href="{{ absURL $data.Plural }}/{{ $key | urlize }}">{{ $key }}</a> ({{ len $value }})</li>
     {{ end }}
   </ul>
 </section>


### PR DESCRIPTION
Currently, the link-href url for tags in both, a post page and the tag overview, looks like this for example.com:

https://example.com/tags/https//example.com//tags/nginx

This is obviously not correct and comes from calling urlize on the BaseURL which makes it URL safe per documentation. Instead, use absURL which is meant for this purpose.